### PR TITLE
Removed old 2d context from RenderingContext

### DIFF
--- a/Ballast.Client/src/app/ballast-viewport.ts
+++ b/Ballast.Client/src/app/ballast-viewport.ts
@@ -80,9 +80,6 @@ export class BallastViewport {
     private prerender = (renderingContext: RenderingContext) => {
         // initial render step goes here
         this.resizeCanvas(renderingContext.canvas);
-        if (renderingContext.canvas2dContext) {
-            renderingContext.canvas2dContext.clearRect(0, 0, renderingContext.canvas.clientWidth, renderingContext.canvas.clientHeight);
-        }
         if (renderingContext.threeWebGLRenderer) {
             renderingContext.threeWebGLRenderer.setSize(
                 renderingContext.canvas.clientWidth, 

--- a/Ballast.Client/src/components/game.ts
+++ b/Ballast.Client/src/components/game.ts
@@ -18,11 +18,6 @@ export class GameComponent extends ComponentBase {
 
     protected render(parent: HTMLElement, renderingContext: RenderingContext) {
 
-        if (renderingContext.canvas2dContext) {
-            renderingContext.canvas2dContext.font = "48px serif";
-            renderingContext.canvas2dContext.fillText(new Date(Date.now()).toLocaleTimeString(), 10, 50);
-        }
-
         if (!this.geometry) {
             this.geometry = new THREE.BoxGeometry( 1, 1, 1 );
         }

--- a/Ballast.Client/src/rendering/rendering-context.ts
+++ b/Ballast.Client/src/rendering/rendering-context.ts
@@ -3,25 +3,15 @@ import * as THREE from 'three';
 export class RenderingContext {
 
     public readonly canvas: HTMLCanvasElement;
-    public readonly canvas2dContext?: CanvasRenderingContext2D;
     public readonly threeWebGLRenderer?: THREE.WebGLRenderer;
     public readonly threePerspectiveCamera?: THREE.PerspectiveCamera;
     public readonly threeScene?: THREE.Scene;
 
     public constructor(canvas: HTMLCanvasElement) {
         this.canvas = canvas;
-        //this.canvas2dContext = this.create2dContext(canvas);
         this.threeWebGLRenderer = this.createRenderer(canvas);
         this.threeScene = this.createScene();
         this.threePerspectiveCamera = this.createCamera(canvas);
-    }
-
-    private create2dContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
-        var canvas2dContext =  canvas.getContext('2d');
-        if (!canvas2dContext) {
-            throw new Error('Could not create canvas 2d context');
-        }
-        return canvas2dContext;
     }
 
     private createRenderer(canvas: HTMLCanvasElement): THREE.WebGLRenderer {


### PR DESCRIPTION
The rendering context used to use a 2D Canvas context, but it has been removed in favor of components working directly with a THREE.WebGLRenderer on the RenderingContext